### PR TITLE
Remove redundant postfix for window type

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ function initRealtimeRequestCounter () {
     //asynchronously each time the `requestStream` receives an event.
 
     forever {
-        from requestStream window timeWindow(10000)
+        from requestStream window time(10000)
         select requestStream.host, count()  as count
         group by requestStream.host
         having count > 10

--- a/streaming-service/api-alerting/api_alert.bal
+++ b/streaming-service/api-alerting/api_alert.bal
@@ -40,7 +40,7 @@ function initRealtimeRequestCounter () {
     // The processing happens asynchronously each time the `requestStream` receives an event.
 
     forever {
-        from requestStream window timeWindow(10000)
+        from requestStream window time(10000)
         select requestStream.host, count()  as count
         group by requestStream.host
         having count > 10


### PR DESCRIPTION
## Purpose
> This PR will remove the `Window` postfix used for the window type name. It is based on latest changes. 